### PR TITLE
Add support for macOS

### DIFF
--- a/src/sys/unix/pty.rs
+++ b/src/sys/unix/pty.rs
@@ -25,8 +25,14 @@ pub fn openpty(options: &OpenptyOptions) -> io::Result<(File, File)> {
         e(libc::unlockpt(master.as_raw_fd()))?;
 
         // Open slave
-        let mut name = [0u8; 32];
-        e(libc::ptsname_r(master.as_raw_fd(), name.as_mut_ptr() as *mut c_char, name.len()))?;
+        // there's no length parameter to the TIOCPTYGNAME call on mac, instead it just assumes the
+        // buffer is 128 bytes
+        let mut name = [0u8; 128];
+        let name_ptr = name.as_mut_ptr() as *mut c_char;
+        #[cfg(not(target_os="macos"))]
+        e(libc::ptsname_r(master.as_raw_fd(), name_ptr, buf.len()))?;
+        #[cfg(target_os="macos")]
+        e(libc::ioctl(master.as_raw_fd(), libc::TIOCPTYGNAME as u64, name_ptr))?;
 
         let mut len = 0;
         while len < name.len() && name[len] != 0 {


### PR DESCRIPTION
ptsname_r is a relatively recent addition to macOS, and it's not included in the libc crate. So use TIOCPTYGNAME instead.